### PR TITLE
Allow hyphens in Hostname

### DIFF
--- a/src/mathswe-client/req/http.ts
+++ b/src/mathswe-client/req/http.ts
@@ -13,7 +13,7 @@ export type Hostname = {
     subdomain: string,
 }
 
-const validHostnameRegex = /^[a-z0-9.]+$/;
+const validHostnameRegex = /^[a-z0-9.-]+$/;
 
 const isValidHostname = (hostname: string): Either<string, string> =>
     validHostnameRegex.test(hostname)

--- a/src/mathswe-client/req/httpl.test.ts
+++ b/src/mathswe-client/req/httpl.test.ts
@@ -38,6 +38,19 @@ describe("newHostnameFromString", () => {
     );
 
     test(
+        "should return valid Hostname for a hostname with hyphened subdomain",
+        () => {
+            const input = "cors-test.codehappy.dev";
+            const expected = right({
+                domainName: "codehappy.dev",
+                subdomain: "cors-test",
+            });
+
+            expect(newHostnameFromString(input)).toEqual(expected);
+        },
+    );
+
+    test(
         "should return an error for an invalid hostname with uppercase letters",
         () => {
             const input = "Sub.Example.Com";


### PR DESCRIPTION
It fixes the rejection of valid hostnames with hyphens.