### PR TITLE
Add router with MS-Client CORS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.1.0-dev",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "fp-ts": "^2.16.9"
+                "fp-ts": "^2.16.9",
+                "itty-router": "^5.0.18"
             },
             "devDependencies": {
                 "@cloudflare/workers-types": "^4.20240909.0",
@@ -1547,6 +1548,12 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/itty-router": {
+            "version": "5.0.18",
+            "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-5.0.18.tgz",
+            "integrity": "sha512-mK3ReOt4ARAGy0V0J7uHmArG2USN2x0zprZ+u+YgmeRjXTDbaowDy3kPcsmQY6tH+uHhDgpWit9Vqmv/4rTXwA==",
+            "license": "MIT"
         },
         "node_modules/js-tokens": {
             "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "wrangler": "^3.77.0"
     },
     "dependencies": {
-        "fp-ts": "^2.16.9"
+        "fp-ts": "^2.16.9",
+        "itty-router": "^5.0.18"
     }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,28 +1,34 @@
-import { unstable_dev } from 'wrangler';
-import type { UnstableDevWorker } from 'wrangler';
-import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
 
-describe('Worker', () => {
-	let worker: UnstableDevWorker;
+import type { UnstableDevWorker } from "wrangler";
+import { unstable_dev } from "wrangler";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-	beforeAll(async () => {
-		worker = await unstable_dev('src/index.ts', {
-			experimental: { disableExperimentalWarning: true },
-		});
-	});
+describe("Worker", () => {
+    let worker: UnstableDevWorker;
 
-	afterAll(async () => {
-		await worker.stop();
-	});
+    beforeAll(async () => {
+        worker = await unstable_dev("src/index.ts", {
+            experimental: { disableExperimentalWarning: true },
+        });
+    });
 
-	it('should return 200 response', async () => {
-		const resp = await worker.fetch();
-		expect(resp.status).toBe(200);
-	});
+    afterAll(async () => {
+        await worker.stop();
+    });
 
-	it('should return the text Hello World!', async () => {
-		const resp = await worker.fetch();
-		const text = await resp.text();
-		expect(text).toBe('Hello World!');
-	});
+    it("should return 200 response", async () => {
+        const resp = await worker.fetch();
+
+        expect(resp.status).toBe(200);
+    });
+
+    it("should return the text Hello World!", async () => {
+        const resp = await worker.fetch();
+        const text = await resp.text();
+
+        expect(text).toBe("Hello World!");
+    });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,6 @@ const router = AutoRouter({
 });
 
 router
-    .get("/", () => (new Response("Hello World!")));
+    .get("/", () => (new Response("MathSwe Ops Services")));
 
 export default router;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,13 @@
 // This file is part of https://github.com/mathswe-ops/services
 
 import { AutoRouter, cors } from "itty-router";
+import { getCorsOrigin } from "./mathswe-client/req/client/client-req";
 
 export interface Env {
 }
 
 const { preflight, corsify } = cors({
+    origin: getCorsOrigin,
     allowMethods: ["GET"],
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,22 @@
-/**
- * Welcome to Cloudflare Workers! This is your first worker.
- *
- * - Run `npm run dev` in your terminal to start a development server
- * - Open a browser tab at http://localhost:8787/ to see your worker in action
- * - Run `npm run deploy` to publish your worker
- *
- * Learn more at https://developers.cloudflare.com/workers/
- */
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
+
+import { AutoRouter, cors } from "itty-router";
+
 export interface Env {
-    // Example binding to KV. Learn more at
-    // https://developers.cloudflare.com/workers/runtime-apis/kv/
-    // MY_KV_NAMESPACE: KVNamespace;  Example binding to Durable Object. Learn
-    // more at
-    // https://developers.cloudflare.com/workers/runtime-apis/durable-objects/
-    // MY_DURABLE_OBJECT: DurableObjectNamespace;  Example binding to R2. Learn
-    // more at https://developers.cloudflare.com/workers/runtime-apis/r2/
-    // MY_BUCKET: R2Bucket;  Example binding to a Service. Learn more at
-    // https://developers.cloudflare.com/workers/runtime-apis/service-bindings/
-    // MY_SERVICE: Fetcher;  Example binding to a Queue. Learn more at
-    // https://developers.cloudflare.com/queues/javascript-apis/ MY_QUEUE:
-    // Queue;
 }
 
-export default {
-    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-        return new Response("Hello World!");
-    },
-};
+const { preflight, corsify } = cors({
+    allowMethods: ["GET"],
+});
+
+const router = AutoRouter({
+    before: [preflight],
+    finally: [corsify],
+});
+
+router
+    .get("/", () => (new Response("Hello World!")));
+
+export default router;

--- a/src/mathswe-client/req/client/client-req.ts
+++ b/src/mathswe-client/req/client/client-req.ts
@@ -2,13 +2,23 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathswe-ops/services
 
-import { pipe } from "fp-ts/function";
+import { identity, pipe } from "fp-ts/function";
 import * as E from "fp-ts/Either";
 import { Either } from "fp-ts/Either";
 import { newOriginFromString, Origin } from "../origin/origin";
+import { toDomainName } from "../origin/origin-domain";
 
 export const getOrigin = (req: Request): Either<string, Origin> => pipe(
     req.headers.get("Origin"),
     E.fromNullable("Request header `Origin` is null."),
     E.flatMap(newOriginFromString),
+);
+
+export const getCorsOrigin
+    = (requestingOrigin: string | null): string | undefined => pipe(
+    requestingOrigin,
+    E.fromNullable(""),
+    E.flatMap(newOriginFromString),
+    E.map(({ domain }) => `https://${ toDomainName.toDomainName(domain) }`),
+    E.fold(_ => undefined, identity),
 );


### PR DESCRIPTION
It adds the Itty-Router dependency that routes CF Worker applications and sets up the CORS origin to only accept MathSwe-Client curated origins.