### PR TITLE
Implement inference of project version from GitHub repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
             "version": "0.1.0-dev",
             "license": "BSD-3-Clause",
             "dependencies": {
+                "@iarna/toml": "^1.7.1",
+                "@types/iarna__toml": "^2.0.5",
                 "fp-ts": "^2.16.9",
                 "itty-router": "^5.0.18"
             },
@@ -576,6 +578,12 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@iarna/toml": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-1.7.1.tgz",
+            "integrity": "sha512-X55PCmaErh7Tk4tg6F0xDxG7wHuomyFTZIeUyTtvZqIGnxF/qLZf5Gvvzp8SL3F/37gb3sZ4z4PVFWQxBOM26w==",
+            "license": "ISC"
+        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -855,11 +863,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/iarna__toml": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.5.tgz",
+            "integrity": "sha512-I55y+SxI0ayM4MBU6yfGJGmi4wRll6wtSeKiFYAZj+Z5Q1DVbMgBSVDYY+xQZbjIlLs/pN4fidnvR8faDrmxPg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/node": {
             "version": "22.5.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
             "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -2292,7 +2308,6 @@
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/unenv": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
         "wrangler": "^3.77.0"
     },
     "dependencies": {
+        "@iarna/toml": "^1.7.1",
+        "@types/iarna__toml": "^2.0.5",
         "fp-ts": "^2.16.9",
         "itty-router": "^5.0.18"
     }

--- a/src/git-platform/git-platform.test.ts
+++ b/src/git-platform/git-platform.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
+import { describe, expect, it } from "vitest";
+import { left, right } from "fp-ts/Either";
+import {
+    gitHub,
+    gitPlatformFromString,
+    gitPlatformToUrl,
+    repoToUrl,
+} from "./git-platform";
+
+describe("GitPlatform", () => {
+    describe("implements FromString for GitProvider", () => {
+        it("constructs GitHub GitProvider from string", () => {
+            expect(gitPlatformFromString.fromString("github"))
+                .toEqual(right(gitHub));
+        });
+
+        it("should return an error for invalid provider", () => {
+            expect(gitPlatformFromString.fromString("bitbucket"))
+                .toEqual(left("Invalid Git Platform."));
+        });
+    });
+
+    describe("gitProviderToUrl", () => {
+        it("should return the correct URL for GitHub", () => {
+            expect(gitPlatformToUrl(gitHub)).toBe("https://github.com");
+        });
+    });
+
+    describe("repoToUrl", () => {
+        it("should construct the correct repository URL for GitHub", () => {
+            const user = "user";
+            const repo = "repo";
+            const expectedUrl = `https://github.com/${ user }/${ repo }`;
+
+            expect(repoToUrl(gitHub, user, repo)).toBe(expectedUrl);
+        });
+    });
+});

--- a/src/git-platform/git-platform.test.ts
+++ b/src/git-platform/git-platform.test.ts
@@ -1,11 +1,13 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathswe-ops/services
+
 import { describe, expect, it } from "vitest";
 import { left, right } from "fp-ts/Either";
 import {
     gitHub,
     gitPlatformFromString,
+    gitPlatformFromUrl,
     gitPlatformToUrl,
     repoToUrl,
 } from "./git-platform";
@@ -36,6 +38,27 @@ describe("GitPlatform", () => {
             const expectedUrl = `https://github.com/${ user }/${ repo }`;
 
             expect(repoToUrl(gitHub, user, repo)).toBe(expectedUrl);
+        });
+    });
+
+    describe("gitPlatformFromUrl", () => {
+        it("should return GitHub platform for a valid GitHub URL", () => {
+            const result = gitPlatformFromUrl("https://github.com/user/repo");
+
+            expect(result).toEqual(right(gitHub));
+        });
+
+        it("should return an error for an invalid URL", () => {
+            const result = gitPlatformFromUrl("invalid-url");
+
+            expect(result)
+                .toStrictEqual(left("Invalid URL: TypeError: Invalid URL"));
+        });
+
+        it("should return an error for an unsupported base URL", () => {
+            const result = gitPlatformFromUrl("https://gitlab.com/user/repo");
+
+            expect(result).toStrictEqual(left("GitPlatform not found."));
         });
     });
 });

--- a/src/git-platform/git-platform.ts
+++ b/src/git-platform/git-platform.ts
@@ -4,7 +4,7 @@
 
 import { FromString } from "../mathswe-ts/string";
 import * as E from "fp-ts/Either";
-import { Either } from "fp-ts/Either";
+import { Either, left } from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import { matchPlain } from "../mathswe-ts/enum";
 
@@ -32,6 +32,29 @@ export const gitPlatformToUrl = (gitProvider: GitPlatform): string => pipe(
     }),
     domainName => `https://${ domainName }`,
 );
+
+export const gitPlatformFromUrl = (urlRaw: string): Either<string, GitPlatform> => {
+    const baseUrlToGitPlatform: Record<string, GitPlatform | undefined> = {
+        "https://github.com": gitHub,
+    };
+
+    let result: Either<string, GitPlatform>;
+
+    try {
+        const url = new URL(urlRaw);
+        const baseUrl = `${ url.protocol }//${ url.host }`;
+
+        result = pipe(
+            baseUrlToGitPlatform[baseUrl],
+            E.fromNullable("GitPlatform not found."),
+        );
+    }
+    catch (error) {
+        result = left(`Invalid URL: ${ error }`);
+    }
+
+    return result;
+};
 
 export const repoToUrl
     = (provider: GitPlatform, user: string, repo: string): string => pipe(

--- a/src/git-platform/git-platform.ts
+++ b/src/git-platform/git-platform.ts
@@ -1,3 +1,41 @@
 // Copyright (c) 2024 Tobias Briones. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathswe-ops/services
+
+import { FromString } from "../mathswe-ts/string";
+import * as E from "fp-ts/Either";
+import { Either } from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import { matchPlain } from "../mathswe-ts/enum";
+
+export type GitPlatform = { tag: "GitHub" }
+
+export const gitHub: GitPlatform = { tag: "GitHub" };
+
+export const gitPlatformFromString: FromString<GitPlatform> = {
+    fromString(string: string): Either<string, GitPlatform> {
+        const stringToGit: Record<string, GitPlatform> = {
+            "github": gitHub,
+        };
+
+        return pipe(
+            stringToGit[string],
+            E.fromNullable("Invalid Git Platform."),
+        );
+    },
+};
+
+export const gitPlatformToUrl = (gitProvider: GitPlatform): string => pipe(
+    gitProvider,
+    matchPlain({
+        GitHub: "github.com",
+    }),
+    domainName => `https://${ domainName }`,
+);
+
+export const repoToUrl
+    = (provider: GitPlatform, user: string, repo: string): string => pipe(
+    provider,
+    gitPlatformToUrl,
+    providerBaseUrl => `${ providerBaseUrl }/${ user }/${ repo }`,
+);

--- a/src/git-platform/git-platform.ts
+++ b/src/git-platform/git-platform.ts
@@ -1,0 +1,3 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services

--- a/src/git-platform/project.ts
+++ b/src/git-platform/project.ts
@@ -61,7 +61,7 @@ export async function inferVersion(
     let result;
 
     if (E.isRight(systemFound)) {
-        const system = pipe(systemFound, requireRight);
+        const system = systemFound.right;
 
         result = await readProjectVersion(gitPlatform, repoUrl, path, system);
     }

--- a/src/git-platform/project.ts
+++ b/src/git-platform/project.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
+

--- a/src/git-platform/project.ts
+++ b/src/git-platform/project.ts
@@ -2,3 +2,109 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathswe-ops/services
 
+import { GitPlatform } from "./git-platform";
+import { none, Option, some } from "fp-ts/Option";
+import { pipe } from "fp-ts/function";
+import * as E from "fp-ts/Either";
+import { Either, left, right } from "fp-ts/Either";
+import { matchPlain } from "../mathswe-ts/enum";
+
+export type BuildSystem = { tag: "Npm" } | { tag: "Cargo" };
+
+export const npm: BuildSystem = { tag: "Npm" };
+
+export const cargo: BuildSystem = { tag: "Cargo" };
+
+export function readBuildSystem(
+    gitPlatform: GitPlatform,
+    url: string,
+): Promise<Either<string, Option<BuildSystem>>> {
+    return pipe(
+        gitPlatform,
+        matchPlain({
+            GitHub: readBuildSystemOnGitHub(url),
+        }),
+    );
+}
+
+type GitHubRepoContent = {
+    name: string,
+}
+
+function detectBuildSystemOnGitHub(
+    repoContents: GitHubRepoContent[],
+): Option<BuildSystem> {
+    const isNpm = (filenames: string[]) =>
+        filenames.includes("package.json") &&
+        filenames.includes("package-lock.json");
+
+    const isCargo = (filenames: string[]) =>
+        filenames.includes("Cargo.toml") &&
+        filenames.includes("Cargo.lock");
+
+    const filenames = repoContents.map(({ name }) => name);
+
+    let system;
+
+    if (isNpm(filenames)) {
+        system = some(npm);
+    }
+    else if (isCargo(filenames)) {
+        system = some(cargo);
+    }
+    else {
+        system = none;
+    }
+
+    return system;
+}
+
+async function readBuildSystemOnGitHub(
+    url: string,
+): Promise<Either<string, Option<BuildSystem>>> {
+    const result = await fetchFileListOnGitHub(url);
+
+    return pipe(
+        result,
+        E.map(detectBuildSystemOnGitHub),
+    );
+}
+
+async function fetchFileListOnGitHub(
+    repoUrl: string,
+): Promise<Either<string, GitHubRepoContent[]>> {
+    const apiUrl = repoUrl
+        .replace("https://github.com/", "https://api.github.com/repos/")
+        .concat("/contents/");
+
+    const init = {
+        headers: {
+            Accept: "application/vnd.github+json",
+        },
+    };
+
+    let result;
+
+    try {
+        const response = await fetch(apiUrl, init);
+        const okResult
+            = response.ok
+              ? right(response)
+              : left(`GitHub API error: ${ response.statusText }`);
+
+        const json
+            = E.isRight(okResult)
+              ? await response.json() as GitHubRepoContent[]
+              : [];
+
+        result = pipe(
+            okResult,
+            E.map(_ => json),
+        );
+    }
+    catch (error) {
+        result = left(`Failed to fetch files: ${ (error as Error).message }`);
+    }
+
+    return result;
+}

--- a/src/git-platform/project.ts
+++ b/src/git-platform/project.ts
@@ -2,18 +2,29 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathswe-ops/services
 
-import { GitPlatform } from "./git-platform";
+import { GitPlatform, gitPlatformFromUrl } from "./git-platform";
+import * as toml from "@iarna/toml";
+import * as O from "fp-ts/Option";
 import { none, Option, some } from "fp-ts/Option";
 import { pipe } from "fp-ts/function";
 import * as E from "fp-ts/Either";
 import { Either, left, right } from "fp-ts/Either";
 import { matchPlain } from "../mathswe-ts/enum";
+import { requireRight } from "../mathswe-ts/require";
 
 export type BuildSystem = { tag: "Npm" } | { tag: "Cargo" };
 
 export const npm: BuildSystem = { tag: "Npm" };
 
 export const cargo: BuildSystem = { tag: "Cargo" };
+
+export const buildFile = (system: BuildSystem): string => pipe(
+    system,
+    matchPlain({
+        Npm: "package.json",
+        Cargo: "Cargo.toml",
+    }),
+);
 
 export function readBuildSystem(
     gitPlatform: GitPlatform,
@@ -25,6 +36,22 @@ export function readBuildSystem(
             GitHub: readBuildSystemOnGitHub(url),
         }),
     );
+}
+
+export async function inferVersion(
+    repoUrl: string,
+): Promise<Either<string, string>> {
+    const gitPlatform = gitPlatformFromUrl(repoUrl);
+    let result;
+
+    if (E.isRight(gitPlatform)) {
+        result = await inferVersionFrom(gitPlatform.right, repoUrl);
+    }
+    else {
+        result = gitPlatform;
+    }
+
+    return result;
 }
 
 type GitHubRepoContent = {
@@ -100,6 +127,12 @@ async function fetchFileListOnGitHub(
         result = pipe(
             okResult,
             E.map(_ => json),
+            E.flatMap(data =>
+                Array.isArray(data)
+                ? right(data)
+                : left("Fail to read project files. Ensure to provide the"
+                       + " correct repository URL"),
+            ),
         );
     }
     catch (error) {
@@ -107,4 +140,151 @@ async function fetchFileListOnGitHub(
     }
 
     return result;
+}
+
+async function inferVersionFrom(
+    gitPlatform: GitPlatform,
+    repoUrl: string,
+): Promise<Either<string, string>> {
+    const systemResult = await readBuildSystem(gitPlatform, repoUrl);
+
+    const systemFound = pipe(
+        systemResult,
+        E.flatMap(
+            O.match(
+                () => left(`Fail to find a build system on ${ repoUrl }`),
+                system => right(system),
+            ),
+        ),
+    );
+
+    let result;
+
+    if (E.isRight(systemFound)) {
+        const system = pipe(systemFound, requireRight);
+
+        result = await readProjectVersion(gitPlatform, repoUrl, system);
+    }
+    else {
+        result = systemFound;
+    }
+
+    return result;
+}
+
+async function readProjectVersion(
+    gitPlatform: GitPlatform,
+    repoUrl: string,
+    system: BuildSystem,
+): Promise<Either<string, string>> {
+    return pipe(
+        gitPlatform,
+        matchPlain({
+            GitHub: readProjectVersionOnGitHub(repoUrl, system),
+        }),
+    );
+}
+
+async function readProjectVersionOnGitHub(
+    repoUrl: string,
+    system: BuildSystem,
+): Promise<Either<string, string>> {
+    const filename = buildFile(system);
+    const fileResult = await readFileOnGitHub(repoUrl, "main", filename);
+
+    return pipe(
+        fileResult,
+        E.flatMap(fileContent => readVersionFromBuildFile(system, fileContent)),
+    );
+}
+
+async function readFileOnGitHub(
+    repoUrl: string,
+    branch: string,
+    filePath: string,
+): Promise<Either<string, string>> {
+    const apiUrl = repoUrl
+        .replace("https://github.com/", "https://raw.githubusercontent.com/")
+        .concat(`/${ branch }/${ filePath }`);
+
+    const init = {
+        headers: {
+            Accept: "application/vnd.github.raw+json",
+        },
+    };
+
+    let result;
+
+    try {
+        const response = await fetch(apiUrl, init);
+        const okResult
+            = response.ok
+              ? right(response)
+              : left(`Fail to fetch ${apiUrl}. GitHub User Content error: ${ response.statusText }`);
+
+        const text = E.isRight(okResult) ? await response.text() : "";
+
+        result = pipe(
+            okResult,
+            E.map(_ => text),
+        );
+    }
+    catch (error) {
+        result = left(`Failed to fetch file ${ filePath }: ${ (error as Error).message }`);
+    }
+
+    return result;
+}
+
+function readVersionFromBuildFile(
+    system: BuildSystem,
+    fileContent: string,
+): Either<string, string> {
+    return pipe(
+        system,
+        matchPlain({
+            Npm: readVersionFromPackageJson(fileContent),
+            Cargo: readVersionFromCargoToml(fileContent),
+        }),
+    );
+}
+
+function readVersionFromPackageJson(
+    packageJson: string,
+): Either<string, string> {
+    let packageResult: Either<string, Record<string, string | undefined>>;
+
+    try {
+        const parse = JSON.parse(packageJson);
+        packageResult = right(parse);
+    }
+    catch (error) {
+        packageResult = left(`Fail to parse package.json: ${ error }`);
+    }
+
+    return pipe(
+        packageResult,
+        E.map(data => data["version"]),
+        E.flatMap(E.fromNullable("Version field not found in package.json")),
+    );
+}
+
+function readVersionFromCargoToml(
+    cargoToml: string,
+): Either<string, string> {
+    let cargoResult: Either<string, Record<string, any>>;
+
+    try {
+        const parsed = toml.parse(cargoToml);
+        cargoResult = right(parsed);
+    }
+    catch (error) {
+        cargoResult = left(`Failed to parse Cargo.toml: ${ error }`);
+    }
+
+    return pipe(
+        cargoResult,
+        E.map(data => data["package"]?.["version"]),
+        E.flatMap(E.fromNullable("Version field not found in Cargo.toml")),
+    );
 }


### PR DESCRIPTION
It defines a Git platform and build-system abstractions such as GitHub, NPM, and Cargo to provide an implementation through the GitHub API that reads a project (including subdirectories) given its repository URL, infers the build system it uses, finally, it reads the project's version.

It only reads public repositories at branch `main` (production) for simplicity.

`InferVersion API`

```ts
export async function inferVersion(
    gitPlatform: GitPlatform,
    user: string,
    repo: string,
    path: Option<string>,
): Promise<Either<string, string>>
```

`Infering Project Versions`

```ts
const rustProject = await inferVersion(
    gitHub,
    "rust-unofficial",
    "awesome-rust",
    none,
);
const jsProject = await inferVersion(
    gitHub,
    "jquery",
    "jquery",
    none,
);
const nestedMvp = await inferVersion(
    gitHub,
    "mathswe-ops",
    "mathswe-ops---mvp",
    some("system"),
);

console.log(rustProject);
console.log(jsProject);
console.log(nestedMvp);
```

`Output: Infering Project Versions`

```
{ _tag: 'Right', right: '0.1.0' }
{ _tag: 'Right', right: '4.0.0-beta.2' }
{ _tag: 'Right', right: '0.1.0' }
```

Besides providing some GitHub and build system abstractions, it's a useful API that an endpoint can use to get the version of a given GitHub project, even if it is a nested subdirectory, like microservice (independently versioned) or mono repository with sub-projects.