### PR TITLE
Implement endpoint badge/version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
             "version": "0.1.0-dev",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@iarna/toml": "^1.7.1",
-                "@types/iarna__toml": "^2.0.5",
                 "fp-ts": "^2.16.9",
-                "itty-router": "^5.0.18"
+                "itty-router": "^5.0.18",
+                "toml": "^3.0.0"
             },
             "devDependencies": {
                 "@cloudflare/workers-types": "^4.20240909.0",
@@ -578,12 +577,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@iarna/toml": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-1.7.1.tgz",
-            "integrity": "sha512-X55PCmaErh7Tk4tg6F0xDxG7wHuomyFTZIeUyTtvZqIGnxF/qLZf5Gvvzp8SL3F/37gb3sZ4z4PVFWQxBOM26w==",
-            "license": "ISC"
-        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -863,19 +856,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/iarna__toml": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@types/iarna__toml/-/iarna__toml-2.0.5.tgz",
-            "integrity": "sha512-I55y+SxI0ayM4MBU6yfGJGmi4wRll6wtSeKiFYAZj+Z5Q1DVbMgBSVDYY+xQZbjIlLs/pN4fidnvR8faDrmxPg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/node": {
             "version": "22.5.4",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
             "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -2253,6 +2238,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/toml": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+            "license": "MIT"
+        },
         "node_modules/tslib": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -2308,6 +2299,7 @@
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unenv": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
         "wrangler": "^3.77.0"
     },
     "dependencies": {
-        "@iarna/toml": "^1.7.1",
-        "@types/iarna__toml": "^2.0.5",
         "fp-ts": "^2.16.9",
-        "itty-router": "^5.0.18"
+        "itty-router": "^5.0.18",
+        "toml": "^3.0.0"
     }
 }

--- a/src/app/badge/badge-template.test.ts
+++ b/src/app/badge/badge-template.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
+
+import { describe, expect, it } from "vitest";
+import { left, right } from "fp-ts/Either";
+import { newVersionFromString } from "./badge-template";
+
+describe("newVersionFromString", () => {
+    it("should return a Version for a valid version string", () => {
+        const result = newVersionFromString("1.0.0");
+        expect(result).toEqual(right("1.0.0"));
+    });
+
+    it("should return an error for an invalid version string", () => {
+        const result = newVersionFromString("1.0");
+        expect(result).toEqual(left("Invalid version 1.0."));
+    });
+
+    it(
+        "should return a Version for a valid version string with pre-release tag",
+        () => {
+            const result = newVersionFromString("1.0.0-beta+exp.sha.5114f85");
+            expect(result).toEqual(right("1.0.0-beta+exp.sha.5114f85"));
+        },
+    );
+
+    it(
+        "should return an error for a version string with invalid format",
+        () => {
+            const result = newVersionFromString("1.0.0.0");
+            expect(result).toEqual(left("Invalid version 1.0.0.0."));
+        },
+    );
+});

--- a/src/app/badge/badge-template.ts
+++ b/src/app/badge/badge-template.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
+
+import * as E from "fp-ts/Either";
+import { Either } from "fp-ts/Either";
+import { identity, pipe } from "fp-ts/function";
+
+const badgeData = `
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{totalWidth}}"
+     height="20"
+     role="img"
+     aria-label="release v{{version}}">
+    <title>release v{{version}}</title>
+    <g shape-rendering="crispEdges">
+        <rect width="48" height="20" fill="#555"/>
+        <rect x="48" width="{{versionRectWidth}}" height="20" fill="#007ec6"/>
+    </g>
+    <g fill="#fff"
+       text-anchor="middle"
+       font-family="Poppins Medium,sans-serif"
+       text-rendering="geometricPrecision"
+       font-size="110">
+        <text x="255"
+              y="140"
+              transform="scale(.1)"
+              fill="#fff"
+              textLength="390">
+          release
+        </text>
+        <text x="{{textX}}"
+              y="140"
+              transform="scale(.1)"
+              fill="#fff"
+              textLength="{{textLength}}">
+          v{{version}}
+        </text>
+    </g>
+</svg>
+`;
+
+export type Version = string;
+
+export const newVersionFromString = (string: string): Either<string, Version> => {
+    const versionRegex = /^\d+\.\d+\.\d+(-\S*)?(\+\S*)?$/;
+
+    return pipe(
+        versionRegex.test(string),
+        E.fromPredicate(identity, () => `Invalid version ${ string }.`),
+        E.map(_ => string),
+    );
+};
+
+export const newVersionBadge = (version: Version): string => {
+    const letterWidth = 56;
+    const length = version.length;
+    const textLength = letterWidth * length;
+    const textX = 255 + textLength + (4*letterWidth);
+    const versionRectWidth = 8 * length + 24;
+    const totalWidth = 48 + versionRectWidth;
+
+    return badgeData
+        .replaceAll("{{version}}", version)
+        .replaceAll("{{textLength}}", textLength.toString())
+        .replaceAll("{{totalWidth}}", totalWidth.toString())
+        .replaceAll("{{textX}}", textX.toString())
+        .replaceAll("{{versionRectWidth}}", versionRectWidth.toString());
+};

--- a/src/app/badge/badge.ts
+++ b/src/app/badge/badge.ts
@@ -15,6 +15,7 @@ import {
     gitPlatformFromString,
 } from "../../git-platform/git-platform";
 import { inferVersion } from "../../git-platform/project";
+import { newVersionBadge, newVersionFromString } from "./badge-template";
 
 type Kv = [string, string];
 
@@ -99,7 +100,16 @@ async function respondVersionBadge(
 
     const versionBadge = pipe(
         version,
-        E.map(version => new Response(version)),
+        E.flatMap(newVersionFromString),
+        E.map(newVersionBadge),
+        E.map(badge => new Response(
+            badge,
+            {
+                headers: {
+                    "Content-Type": "image/svg+xml",
+                },
+            },
+        )),
     );
 
     let result = error();

--- a/src/app/badge/badge.ts
+++ b/src/app/badge/badge.ts
@@ -127,6 +127,7 @@ async function respondVersionBadge(
 function domainErrorToIttyError(left: Left<string>): Response {
     const msg = left.left;
     const possibleReasons = [
+        { reason: "Not Found", code: 404 },
         { reason: "Fail to find a build system", code: 404 },
         { reason: "GitHub API error", code: 502 },
         { reason: "Fail to read project files", code: 500 },

--- a/src/app/badge/badge.ts
+++ b/src/app/badge/badge.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2024 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This file is part of https://github.com/mathswe-ops/services
+
+import * as E from "fp-ts/Either";
+import { Either, Left } from "fp-ts/Either";
+import * as O from "fp-ts/Option";
+import { Option } from "fp-ts/Option";
+import { pipe } from "fp-ts/function";
+import { error, IRequest } from "itty-router";
+import { map } from "fp-ts/es6/Array";
+import { sequenceT } from "fp-ts/Apply";
+import {
+    GitPlatform,
+    gitPlatformFromString,
+} from "../../git-platform/git-platform";
+import { inferVersion } from "../../git-platform/project";
+
+type Kv = [string, string];
+
+type RawKv = [string, string | undefined];
+
+type VersionBadgeParams = {
+    gitPlatform: GitPlatform,
+    user: string,
+    repo: string,
+    root: Option<string>
+}
+
+export async function handleVersionBadge(req: IRequest): Promise<Response> {
+    const paramNames = ["gitProvider", "user", "repo"];
+    const { params, query } = req;
+    const root: Option<string> = pipe(
+        query["path"],
+        O.fromNullable,
+        O.flatMap(value =>
+            Array.isArray(value)
+            ? O.fromNullable(value[0])
+            : O.some(value),
+        ),
+    );
+
+    const paramToKeyValue = (param: string): RawKv => [param, params[param]];
+
+    const kvToEither = ([key, rawValue]: RawKv): Either<string, Kv> => pipe(
+        rawValue,
+        E.fromNullable(`Missing route param: ${ key }`),
+        E.map(value => [key, value]),
+    );
+
+    const flattenKvEither
+        = ([git, user, repo]: Either<string, Kv>[]): Either<string, Kv[]> =>
+        sequenceT(E.Apply)(git, user, repo);
+
+    const kvToValue = ([_, value]: Kv): string => value;
+
+    const toParams
+        = ([git, user, repo]: string[]): Either<string, VersionBadgeParams> => pipe(
+        git,
+        gitPlatformFromString.fromString,
+        E.map(gitProvider => ({ gitPlatform: gitProvider, user, repo, root })),
+    );
+
+    const kvsToParams = (kvs: Kv[]): Either<string, VersionBadgeParams> => pipe(
+        kvs,
+        map(kvToValue),
+        toParams,
+    );
+
+    const badgeParams: Either<Response, VersionBadgeParams> = pipe(
+        paramNames,
+        map(paramToKeyValue),
+        map(kvToEither),
+        flattenKvEither,
+        E.mapLeft(msg => error(400, msg)),
+        E.flatMap(kvs => pipe(
+            kvs,
+            kvsToParams,
+            E.mapLeft(msg => error(400, msg)),
+        )),
+    );
+
+    let result: Response;
+
+    if (E.isRight(badgeParams)) {
+        result = await respondVersionBadge(badgeParams.right);
+    }
+    else {
+        result = badgeParams.left;
+    }
+
+    return result;
+}
+
+async function respondVersionBadge(
+    { gitPlatform, user, repo, root }: VersionBadgeParams,
+): Promise<Response> {
+    const version = await inferVersion(gitPlatform, user, repo, root);
+
+    const versionBadge = pipe(
+        version,
+        E.map(version => new Response(version)),
+    );
+
+    let result = error();
+
+    if (E.isRight(versionBadge)) {
+        result = versionBadge.right;
+    }
+    else if (E.isLeft(versionBadge)) {
+        result = domainErrorToIttyError(versionBadge);
+    }
+
+    return result;
+}
+
+function domainErrorToIttyError(left: Left<string>): Response {
+    const msg = left.left;
+    const possibleReasons = [
+        { reason: "Fail to find a build system", code: 404 },
+        { reason: "GitHub API error", code: 502 },
+        { reason: "Fail to read project files", code: 500 },
+        { reason: "Failed to fetch files", code: 502 },
+        { reason: "GitHub User Content error", code: 500 },
+        { reason: "Version field not found", code: 400 },
+        { reason: "Failed to parse", code: 400 },
+    ];
+
+    const matchedReason = possibleReasons
+        .find(({ reason }) => msg.includes(reason));
+
+    const code = matchedReason ? matchedReason.code : 500;
+
+    return error(code, msg);
+}

--- a/src/git-platform/project.ts
+++ b/src/git-platform/project.ts
@@ -3,13 +3,13 @@
 // This file is part of https://github.com/mathswe-ops/services
 
 import { GitPlatform, repoToUrl } from "./git-platform";
-import * as toml from "@iarna/toml";
 import * as O from "fp-ts/Option";
 import { none, Option, some } from "fp-ts/Option";
 import { pipe } from "fp-ts/function";
 import * as E from "fp-ts/Either";
 import { Either, left, right } from "fp-ts/Either";
 import { matchPlain } from "../mathswe-ts/enum";
+import * as toml from "toml";
 
 export type BuildSystem = { tag: "Npm" } | { tag: "Cargo" };
 

--- a/src/git-platform/project.ts
+++ b/src/git-platform/project.ts
@@ -127,6 +127,7 @@ async function fetchFileListOnGitHub(
     const init = {
         headers: {
             Accept: "application/vnd.github+json",
+            "User-Agent": "mathswe-ops-services",
         },
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 
 import { AutoRouter, cors } from "itty-router";
 import { getCorsOrigin } from "./mathswe-client/req/client/client-req";
+import { handleVersionBadge } from "./app/badge/badge";
 
 export interface Env {
 }
@@ -19,6 +20,7 @@ const router = AutoRouter({
 });
 
 router
-    .get("/", () => (new Response("MathSwe Ops Services")));
+    .get("/", () => (new Response("MathSwe Ops Services")))
+    .get("/badge/version/:gitProvider/:user/:repo", handleVersionBadge);
 
 export default router;


### PR DESCRIPTION
It provides the new endpoint that takes a repository GitHub URL, or one of its subprojects (e.g., microservice), and responds with the badge showing its current version.